### PR TITLE
docs: Fix missing header for `TranslatedParticle`

### DIFF
--- a/docs/main/_sources/flame/rendering/particles.md.txt
+++ b/docs/main/_sources/flame/rendering/particles.md.txt
@@ -162,9 +162,8 @@ All the implementations are available in the
 [particles](https://github.com/flame-engine/flame/tree/main/packages/flame/lib/src/particles) folder
 on the Flame repository.
 
-Simply translates the underlying `Particle` to a specified `Vector2` within the rendering `Canvas`.
-Does not change or alter its position, consider using `MovingParticle` or `AcceleratedParticle`
-where change of position is required.
+
+## TranslatedParticle
 
 Simply translates the underlying `Particle` to a specified `Vector2` within the rendering `Canvas`.
 Does not change or alter its position, consider using `MovingParticle` or `AcceleratedParticle`


### PR DESCRIPTION
Built-in particles is missing the section header for `TranslatedParticle` and had some copy-pasta duplication.