### PR TITLE
docs: add noindex meta tag to non-latest index.html

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -101,6 +101,8 @@ function generate_docs_for_version {
   fi
   
   cp -r $tmp_flame_src/doc/_build/html "docs/$version"
+  no_index_string="<meta name=\"robots\" content=\"noindex\">"
+  sed -i "/<head>/a  $no_index_string" docs/$version/index.html
 
   echo "$version" >> docs/versions.txt
 }


### PR DESCRIPTION
appends a new meta tag right after the head for non latest versions' index.html while generating docs

Related Issue: flame-engine/flame#2345

### Additional Context:
The `sed` command works weird for MacOS. So, I couldn't test this properly. Please let me know if this doesn't work.