### PR TITLE
fix: Add meta robots noindex tag to ALL html files in older versions

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -102,7 +102,7 @@ function generate_docs_for_version {
   
   cp -r $tmp_flame_src/doc/_build/html "docs/$version"
   no_index_string="<meta name=\"robots\" content=\"noindex\">"
-  sed -i "/<head>/a  $no_index_string" docs/$version/index.html
+  find "docs/$version" -type f -name "*.html" -exec sed -i "/<head>/a  $no_index_string" {} +
 
   echo "$version" >> docs/versions.txt
 }


### PR DESCRIPTION
Fix for #17 that improves on #16 by adding the tag to all .html files (except those in `latest`).