### PR TITLE
Fix Gamepads repository url

### DIFF
--- a/docs/1.18.0/_sources/flame/inputs/other_inputs.md.txt
+++ b/docs/1.18.0/_sources/flame/inputs/other_inputs.md.txt
@@ -139,7 +139,7 @@ else which isn't a pure sprite.
 ## Gamepad
 
 Flame has a dedicated plugin to support external game controllers (gamepads).
-Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepad).
+Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepads).
 
 
 ## AdvancedButtonComponent

--- a/docs/1.18.0/flame/inputs/other_inputs.html
+++ b/docs/1.18.0/flame/inputs/other_inputs.html
@@ -448,7 +448,7 @@ else which isn’t a pure sprite.</p>
 <section id="gamepad">
 <h2>Gamepad<a class="headerlink" href="#gamepad" title="Link to this heading">¶</a></h2>
 <p>Flame has a dedicated plugin to support external game controllers (gamepads).
-Find more information in the <a class="reference external" href="https://github.com/flame-engine/gamepad">Gamepads repository</a>.</p>
+Find more information in the <a class="reference external" href="https://github.com/flame-engine/gamepads">Gamepads repository</a>.</p>
 </section>
 <section id="advancedbuttoncomponent">
 <h2>AdvancedButtonComponent<a class="headerlink" href="#advancedbuttoncomponent" title="Link to this heading">¶</a></h2>

--- a/docs/latest/_sources/flame/inputs/other_inputs.md.txt
+++ b/docs/latest/_sources/flame/inputs/other_inputs.md.txt
@@ -139,7 +139,7 @@ else which isn't a pure sprite.
 ## Gamepad
 
 Flame has a dedicated plugin to support external game controllers (gamepads).
-Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepad).
+Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepads).
 
 
 ## AdvancedButtonComponent

--- a/docs/main/_sources/flame/inputs/other_inputs.md.txt
+++ b/docs/main/_sources/flame/inputs/other_inputs.md.txt
@@ -139,7 +139,7 @@ else which isn't a pure sprite.
 ## Gamepad
 
 Flame has a dedicated plugin to support external game controllers (gamepads).
-Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepad).
+Find more information in the [Gamepads repository](https://github.com/flame-engine/gamepads).
 
 
 ## AdvancedButtonComponent

--- a/docs/main/flame/inputs/other_inputs.html
+++ b/docs/main/flame/inputs/other_inputs.html
@@ -449,7 +449,7 @@ else which isn’t a pure sprite.</p>
 <section id="gamepad">
 <h2>Gamepad<a class="headerlink" href="#gamepad" title="Link to this heading">¶</a></h2>
 <p>Flame has a dedicated plugin to support external game controllers (gamepads).
-Find more information in the <a class="reference external" href="https://github.com/flame-engine/gamepad">Gamepads repository</a>.</p>
+Find more information in the <a class="reference external" href="https://github.com/flame-engine/gamepads">Gamepads repository</a>.</p>
 </section>
 <section id="advancedbuttoncomponent">
 <h2>AdvancedButtonComponent<a class="headerlink" href="#advancedbuttoncomponent" title="Link to this heading">¶</a></h2>


### PR DESCRIPTION
The URL for the Gamepads repository was returning a 404 error, so I have fixed it. There were more files to modify than I initially expected. Is there a way to update one file and have the others generated automatically? (Since I wasn't sure, I manually updated all the files, but if there's a more appropriate way to make this correction, feel free to close this PR and apply the changes in the correct manner.)