### PR TITLE
Update publish.sh to fix --VERSION--

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -105,7 +105,7 @@ function pre_process {
     find .. -name "*.md" -exec sed -i "/<VERSION>.*/a $output" {} \;
     find .. -name "*.md" -exec sed -i "s/ <VERSION>//" {} \;
   else
-    find .. -name "*.md" -exec sed -i "s/--VERSION--/$version/" {} \;
+    find .. -name "*.md" -exec sed -i "s/--VERSION--/${version#v}/" {} \;
     find .. -name "*.md" -exec sed -i "s/<VERSION>/$version/" {} \;
   fi
 }


### PR DESCRIPTION
When we moved to v prefixed version names, this broke https://pub.dev/documentation/flame/v1.30.1/ and the pubpsec.yaml of Bare Flame game tutorial.
<img width="500" height="403" alt="Screenshot 2025-08-04 at 10 53 12 AM" src="https://github.com/user-attachments/assets/006b2b8f-f89c-4d89-92b2-06cc063faff5" />

These appear to be the only two usages of --VERSION--, so this should fix them both.