### PR TITLE
ci: Build doc versions in parallel and fix the failing app builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,22 +3,55 @@ name: GH-Pages
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  versions:
     runs-on: ubuntu-latest
-
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
+      latest: ${{ steps.list.outputs.latest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - id: list
+        run: ./publish.sh list >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: versions
+    runs-on: ubuntu-latest
+    strategy:
+      # One broken version should not prevent the others from being published.
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.versions.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v3
         with:
-          melos-version: 7.0.0-dev.7
+          melos-version: 8.2.2
           run-bootstrap: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v7
         with:
-          node-version: 16
-      - run: ./publish.sh
+          node-version: 22
+      - run: ./publish.sh build "${{ matrix.version }}" "${{ needs.versions.outputs.latest }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docs-${{ matrix.version }}
+          path: out/
+          retention-days: 1
+
+  publish:
+    needs: [versions, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: docs-*
+      - run: ./publish.sh assemble '${{ needs.versions.outputs.targets }}'

--- a/publish.sh
+++ b/publish.sh
@@ -1,34 +1,33 @@
 #!/bin/bash -e
+#
+# Builds the versioned Flame documentation.
+#
+# Usage:
+#   ./publish.sh                      Build every version sequentially, then
+#                                     assemble docs/ and push (local/full run).
+#   ./publish.sh list                 Print `latest` and `targets` (a JSON array
+#                                     of everything to build, in site order).
+#   ./publish.sh build <ver> <latest> Build a single version into out/.
+#   ./publish.sh assemble <targets>   Combine out/ (or artifacts/) into docs/
+#                                     and push.
+#
+# The CI workflow uses `list` to fan out one `build` job per version, then a
+# single `assemble` job to publish. Splitting it this way keeps one copy of the
+# build logic rather than duplicating it between the script and the workflow.
 
 tmp_flame_src='_flame'
 tmp_stash='_stash'
+flame_repo='https://github.com/flame-engine/flame.git'
+out_dir='out'
 
 function main {
-  prepare_flame_repo
-  prepare_docs
-
-  # Obtain the list of documentation versions to build. The list is
-  # created from git tags, skipping the versions that started with 0.
-  section "List of versions to build:"
-  cd $tmp_flame_src
-  # Removes all the old versions that doesn't support Melos 7 and pub workspaces.
-  list=$(git for-each-ref --sort=creatordate --format '%(refname:short)' 'refs/tags/v*' | sed -n '29,$p' | sort -rV)
-  cd -
-  echo "$list"
-  latest_version=$(head -n 1 <<< "$list")
-  sed -i "s/FLAME_VERSION/latest/g" docs/index.html
-  sed -i "s/FLAME_VERSION/latest/g" docs/404.html
-
-  generate_docs_for_version main "$latest_version"
-  while IFS= read -r line; do
-    generate_docs_for_version "$line" "$latest_version"
-  done <<< "$list"
-
-  git_push
-
-  rm -rf $tmp_flame_src
-  rm -rf $tmp_stash
-  section "Done."
+  case "${1:-}" in
+    list) cmd_list ;;
+    build) cmd_build "$2" "$3" ;;
+    assemble) cmd_assemble "$2" ;;
+    '') cmd_all ;;
+    *) echo "Unknown command: $1" >&2; exit 1 ;;
+  esac
 }
 
 function section {
@@ -38,11 +37,61 @@ function section {
   echo -e "\033[1;32m#-----------------------------------------------------------\033[m"
 }
 
+# Obtain the list of documentation versions to build. The list is created from
+# git tags, skipping the versions that started with 0, and removing all the old
+# versions that don't support Melos 7 and pub workspaces.
+function version_list {
+  git -C $tmp_flame_src for-each-ref --sort=creatordate \
+    --format '%(refname:short)' 'refs/tags/v*' | sed -n '29,$p' | sort -rV
+}
+
+# Prints `latest` and `targets` as `key=value` lines, ready to be appended to
+# $GITHUB_OUTPUT. `targets` is main followed by the versions in descending
+# order, which is also the order they are listed in on the site.
+function cmd_list {
+  rm -rf $tmp_flame_src
+  # Only the refs are needed here, so skip blobs and the working copy.
+  git clone --filter=blob:none --no-checkout --quiet $flame_repo $tmp_flame_src
+  local list latest targets
+  list=$(version_list)
+  latest=$(head -n 1 <<< "$list")
+  targets=$(printf 'main\n%s\n' "$list" | jq -R . | jq -s -c .)
+  rm -rf $tmp_flame_src
+  echo "latest=$latest"
+  echo "targets=$targets"
+}
+
+function cmd_build {
+  prepare_flame_repo
+  generate_docs_for_version "$1" "$2"
+}
+
+function cmd_all {
+  local list latest targets
+  prepare_flame_repo
+  section "List of versions to build:"
+  list=$(version_list)
+  echo "$list"
+  latest=$(head -n 1 <<< "$list")
+  targets=$(printf 'main\n%s\n' "$list" | jq -R . | jq -s -c .)
+
+  generate_docs_for_version main "$latest"
+  while IFS= read -r line; do
+    generate_docs_for_version "$line" "$latest"
+  done <<< "$list"
+
+  cmd_assemble "$targets"
+
+  rm -rf $tmp_flame_src
+  rm -rf $tmp_stash
+  section "Done."
+}
+
 function prepare_flame_repo {
   section 'Downloading Flame repository'
   rm -rf $tmp_flame_src
   rm -rf $tmp_stash
-  git clone https://github.com/flame-engine/flame.git $tmp_flame_src
+  git clone $flame_repo $tmp_flame_src
   mkdir $tmp_stash
   cp -r $tmp_flame_src/doc/_sphinx $tmp_stash
   cp -r $tmp_flame_src/scripts $tmp_stash
@@ -56,6 +105,9 @@ function prepare_docs {
   cp -r template docs/
 }
 
+# Builds one version into out/<version>. The latest version is additionally
+# copied to out/latest, before the noindex marker is added, so that only the
+# versioned copy is hidden from search engines.
 function generate_docs_for_version {
   version=$1
   latest_version=$2
@@ -90,15 +142,17 @@ function generate_docs_for_version {
   make html
   cd -
 
+  mkdir -p $out_dir
   if [[ "$version" == "$latest_version" ]]; then
-    cp -r $tmp_flame_src/doc/_build/html "docs/latest"
+    rm -rf "$out_dir/latest"
+    cp -r $tmp_flame_src/doc/_build/html "$out_dir/latest"
   fi
-  
-  cp -r $tmp_flame_src/doc/_build/html "docs/$version"
-  no_index_string="<meta name=\"robots\" content=\"noindex\">"
-  find "docs/$version" -type f -name "*.html" -exec sed -i "/<head>/a  $no_index_string" {} +
 
-  echo "$version" >> docs/versions.txt
+  rm -rf "${out_dir:?}/$version"
+  cp -r $tmp_flame_src/doc/_build/html "$out_dir/$version"
+  no_index_string="<meta name=\"robots\" content=\"noindex\">"
+  find "$out_dir/$version" -type f -name "*.html" \
+    -exec sed -i "/<head>/a  $no_index_string" {} +
 }
 
 function pre_process {
@@ -115,6 +169,31 @@ function pre_process {
   fi
 }
 
+# Combines the per-version builds into docs/ and publishes them. Version
+# directories are read from artifacts/*/ (one directory per CI artifact) when
+# present, and from out/ otherwise.
+function cmd_assemble {
+  local targets="$1"
+  section "Assembling docs"
+  prepare_docs
+  sed -i "s/FLAME_VERSION/latest/g" docs/index.html
+  sed -i "s/FLAME_VERSION/latest/g" docs/404.html
+
+  if compgen -G 'artifacts/*/' > /dev/null; then
+    cp -r artifacts/*/. docs/
+  else
+    cp -r $out_dir/. docs/
+  fi
+
+  # versions.txt drives the version picker, so the order has to be stable:
+  # main first, then newest to oldest.
+  jq -r '.[]' <<< "$targets" > docs/versions.txt
+  echo "Published versions:"
+  cat docs/versions.txt
+
+  git_push
+}
+
 function git_push {
   section "Publishing to Git"
   git config user.email "contact@blue-fire.xyz"
@@ -128,4 +207,4 @@ function git_push {
   fi
 }
 
-main
+main "$@"

--- a/publish.sh
+++ b/publish.sh
@@ -116,6 +116,14 @@ function generate_docs_for_version {
 
   cd $tmp_flame_src
   git checkout -f "$version"
+  # `git checkout -f` leaves ignored files alone, so build output generated for
+  # a previously built version survives into this one. That breaks the Flutter
+  # apps: `.dart_tool/` holds a generated web plugin registrant, and a
+  # registrant left behind by a version using rive ^0.14 imports
+  # `package:rive_native`, which versions using rive ^0.13 do not depend on.
+  # The app then fails to compile with "Couldn't resolve the package
+  # 'rive_native'". Every version has to start from a pristine checkout.
+  git clean -xfd
   cd -
   rm -rf $tmp_flame_src/doc/_sphinx
   cp -r $tmp_stash/_sphinx $tmp_flame_src/doc/


### PR DESCRIPTION
# Description

Two things, both found while investigating why [run 29694895994] took **4h17m**: the embedded
Flutter apps were failing to compile for every version older than v1.36.0, and the versions
were built sequentially when they are independent of each other.

## Fix the failing app builds

Every version older than v1.36.0 failed to compile its embedded Flutter apps with:

```
Error: Couldn't resolve the package 'rive_native' in 'package:rive_native/rive_native_plugin_web.dart'
Error: Undefined name 'RiveNativePlugin'.
Error: Compilation failed.
```

590 of the 647 compiles in that run failed this way. It is not a dependency problem: rive
`0.13.20` does not depend on `rive_native` at all, only `0.14.0`+ does. It is state leaking
between versions.

All versions are built in the same clone, newest first. `git checkout -f` does not touch
ignored files, and `.dart_tool/`, `.flutter-plugins-dependencies` and `**/build/` are all
gitignored. `.dart_tool/` holds a generated web plugin registrant, so once v1.36.0 (rive
`^0.14`) has been built, a registrant importing `package:rive_native` survives the checkout
into v1.35.1 (rive `^0.13`), which does not depend on it. The import no longer resolves and
every app build fails from there on down. The version boundary matches exactly where flame
moved from rive `^0.13.20` to `^0.14.0`.

Adding `git clean -xfd` after the checkout makes each version start from a pristine tree.
Note `-x` is required: plain `git clean -fd` would skip these files precisely because they
are ignored.

Reproduced in one clone, which is exactly what CI does:

| step | state handling | result |
| --- | --- | --- |
| v1.36.0 | clean | `✓ Built build/web` |
| v1.35.1 | `git checkout -f` only | `Couldn't resolve the package 'rive_native'` |
| v1.35.1 | `git clean -xfd` first | `✓ Built build/web` |

This is a correctness fix as much as a speed one: the embedded apps in every published
version below v1.36.0 are currently broken.

## Build the versions in parallel

The versions are independent, so they are now built by a matrix with one job per version, plus
a single job that assembles the results and pushes. `publish.sh` gains `list`, `build` and
`assemble` subcommands which the workflow drives:

- `list` clones the Flame repo blob-filtered and no-checkout (it only needs the refs) and
  emits `latest` and `targets` for the matrix.
- `build <version> <latest>` builds one version into `out/`.
- `assemble <targets>` merges the artifacts into `docs/` and pushes.

Running `./publish.sh` without arguments still performs the full sequential build locally, so
the build logic is not duplicated between the script and the workflow.

The push stays in the single `publish` job so the builders never race on the branch, and
`fail-fast: false` means one broken version does not prevent the others from being published.

Note the matrix also makes the state leak structurally impossible, since every version gets a
fresh runner and a fresh clone. The `git clean -xfd` is kept anyway: it is what makes the
local sequential path correct, and it should not depend on how CI happens to be sharded.

Expected wall clock is roughly 5 minutes, down from 4h17m.

## Action and runtime updates

Bundled here since they touch the same file:

| | from | to |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v3 | v7 |
| Node | 16 (EOL since 2023) | 22 |
| Melos | 7.0.0-dev.7 | 8.2.2 |

`subosito/flutter-action@v2` and `bluefireteam/melos-action@v3` are already on their latest
majors. The old Melos pin could not satisfy v1.38.0, which requires `^8.1.0`, so `main` and
the newest tag were relying on `melos bootstrap || echo ...` swallowing the failure. Melos
8.2.2 was checked against v1.25.0, the oldest tag in the build list: it does not reject a
workspace declaring `^7`, and loads all packages and the script registry, so
`melos run doc-setup` resolves.

## Related

flame-engine/flame#3953 stops the `flutter-app` directive from recompiling an app that
already failed, so a broken app costs one compile rather than one per referencing page. It is
independent of this PR, but it is what bounds the damage if a version ever does fail again.

## Testing instructions

The workflow is `workflow_dispatch` only, so the real test is dispatching it from this branch
and checking that:

1. The `versions` job outputs 17 targets with `latest=v1.38.0`.
2. 17 `build` jobs run in parallel, each uploading a `docs-<version>` artifact.
3. **No job logs `Couldn't resolve the package 'rive_native'`**, and each version logs 5
   successful `Compiling Flutter app` lines rather than dozens of repeats.
4. The `publish` job produces a `docs/` tree matching the sequential build: one directory per
   version, a `docs/latest` copy, and `docs/versions.txt` listing `main` first then newest to
   oldest.
5. `docs/latest` has no `noindex` marker while every versioned directory does. The ordering in
   `generate_docs_for_version` matters here: `latest` is copied before the marker is added.

Worth spot-checking a page like `flame/effects/anchor_effects` on an older version once
published, since those embedded apps should now actually run.

[run 29694895994]: https://github.com/flame-engine/flame-docs-site/actions/runs/29694895994
